### PR TITLE
Code enhancements for wffweb-12.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wffweb demo app with wffweb-12.0.0
+# wffweb demo app with wffweb-12.x.x
 #### It contains sample code for url rewriting/routing, JWT token based authentication/authorization and configuration for multi node support for scaling.
 
 [Fork](https://github.com/webfirmframework/wffweb-demo-deployment/fork) and [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
@@ -16,7 +16,6 @@ After deployed to Heroku, set the following config vars in Heroku Settings
 | ENABLE_HEARTBEAT  (required only if Heroku)  |         true                    |
 
 
-##### This demo project is deployed at [wffweb.herokuapp.com](https://wffweb.herokuapp.com)
 
 ##### To run this project in your local machine, open this project with IntelliJ IDEA as a maven project and run `com.webfirmframework.web.launcher.Main.main` method.
 

--- a/src/main/java/com/webfirmframework/ui/page/component/SampleFilesUploadComponent.java
+++ b/src/main/java/com/webfirmframework/ui/page/component/SampleFilesUploadComponent.java
@@ -115,6 +115,8 @@ public class SampleFilesUploadComponent extends Div {
             return null;
         });
 
+        SampleFilesUploadComponent.super.addParentLostListener(event -> documentModel.browserPage().removeServerMethod(FILE_UPLOAD_SERVER_METHOD));
+
         final String fileUploadURL = ServerConstants.DOMAIN_URL + documentModel.contextPath() + ServerConstants.FILE_UPLOAD_URI;
         new Form(this, new Id("fileUploadForm"), new OnSubmit(true, """
                 loadingIcon.hidden = false;

--- a/src/main/java/com/webfirmframework/ui/page/layout/IndexPageLayout.java
+++ b/src/main/java/com/webfirmframework/ui/page/layout/IndexPageLayout.java
@@ -112,8 +112,9 @@ public class IndexPageLayout extends Html {
         });
 
         //To remove serverMethod added by SampleFilesUploadComponent if the uri is not NavigationURI.SAMPLE_FILES_UPLOAD
-        new NoTag(mainDiv).whenURI(uriEvent -> !NavigationURI.SAMPLE_FILES_UPLOAD.getUri(documentModel).equals(uriEvent.uriAfter()),
-                tagEvent -> documentModel.browserPage().removeServerMethod(SampleFilesUploadComponent.FILE_UPLOAD_SERVER_METHOD));
+        //but since wffweb-12.0.1 it can be achieved by adding ParentLostListener on the component
+//        new NoTag(mainDiv).whenURI(uriEvent -> !NavigationURI.SAMPLE_FILES_UPLOAD.getUri(documentModel).equals(uriEvent.uriAfter()),
+//                tagEvent -> documentModel.browserPage().removeServerMethod(SampleFilesUploadComponent.FILE_UPLOAD_SERVER_METHOD));
 
         URIStateSwitch componentDiv = new Div(mainDiv);
 


### PR DESCRIPTION
To remove server method using `ParentLostListener` instead of `whenURI` event method.